### PR TITLE
feat: allow for specifiying model package, use model definition

### DIFF
--- a/bulkgen/bulk.gotpl
+++ b/bulkgen/bulk.gotpl
@@ -1,15 +1,20 @@
 {{ reserveImport "context"  }}
 {{ reserveImport "errors"  }}
 
-{{ reserveImport "github.com/theopenlane/core/internal/ent/generated" }}
-{{ reserveImport "github.com/theopenlane/core/internal/ent/generated/privacy"}}
+{{- if $.EntImport }}
+{{ reserveImport $.EntImport }}
+{{- end }}
+
+{{- if $.ModelImport }}
+{{ reserveImport $.ModelImport }}
+{{- end }}
 
 {{ $root := . }}
 
 {{ range $object := .Objects }}
 
 // bulkCreate{{ $object.Name }} uses the CreateBulk function to create multiple {{ $object.Name }} entities
-func (r *mutationResolver) bulkCreate{{ $object.Name }} (ctx context.Context, input []*generated.Create{{ $object.Name }}Input) (*{{ $object.Name }}BulkCreatePayload, error) {
+func (r *mutationResolver) bulkCreate{{ $object.Name }} (ctx context.Context, input []*generated.Create{{ $object.Name }}Input) (*{{ $root.ModelPackage }}{{ $object.Name }}BulkCreatePayload, error) {
     c := withTransactionalMutation(ctx)
 	builders := make([]*generated.{{ $object.Name }}Create, len(input))
 	for i, data := range input {
@@ -22,7 +27,7 @@ func (r *mutationResolver) bulkCreate{{ $object.Name }} (ctx context.Context, in
 	}
 
 	// return response
-	return &{{ $object.Name }}BulkCreatePayload{
+	return &{{ $root.ModelPackage }}{{ $object.Name }}BulkCreatePayload{
 		{{ $object.PluralName }}: res,
 	}, nil
 }

--- a/bulkgen/bulkresolvers.go
+++ b/bulkgen/bulkresolvers.go
@@ -92,16 +92,20 @@ func (m *Plugin) GenerateCode(data *codegen.Data) error {
 // generateSingleFile generates the bulk resolver code, this is all done in a single file and
 // used by the resolvergen plugin for each bulk resolver
 func (m *Plugin) generateSingleFile(data codegen.Data) error {
-	modelPkg := data.Config.Model.Package
-	if modelPkg != "" {
-		modelPkg += "."
+	inputData := BulkResolverBuild{
+		Objects:     []Object{},
+		ModelImport: m.ModelPackage,
+		EntImport:   m.EntGeneratedPackage,
 	}
 
-	inputData := BulkResolverBuild{
-		Objects:      []Object{},
-		ModelImport:  m.ModelPackage,
-		EntImport:    m.EntGeneratedPackage,
-		ModelPackage: modelPkg,
+	// only add the model package if te import is not empty
+	if m.ModelPackage != "" {
+		modelPkg := data.Config.Model.Package
+		if modelPkg != "" {
+			modelPkg += "."
+		}
+
+		inputData.ModelPackage = modelPkg
 	}
 
 	for _, f := range data.Schema.Mutation.Fields {

--- a/bulkgen/bulkresolvers.go
+++ b/bulkgen/bulkresolvers.go
@@ -19,8 +19,41 @@ func New() plugin.Plugin {
 	return &Plugin{}
 }
 
+// Options is a function to set the options for the plugin
+type Options func(*Plugin)
+
+// NewWithOptions returns a new plugin with the given options
+func NewWithOptions(opts ...Options) *Plugin {
+	r := &Plugin{}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
+}
+
+// WithModelPackage sets the model package for the gqlgen model
+func WithModelPackage(modelPackage string) Options {
+	return func(p *Plugin) {
+		p.ModelPackage = modelPackage
+	}
+}
+
+// WithEntGeneratedPackage sets the ent generated package for the gqlgen model
+func WithEntGeneratedPackage(entPackage string) Options {
+	return func(p *Plugin) {
+		p.EntGeneratedPackage = entPackage
+	}
+}
+
 // Plugin is a gqlgen plugin to generate bulk resolver functions used for mutations
-type Plugin struct{}
+type Plugin struct {
+	// ModelPackage is the package name for the gqlgen model
+	ModelPackage string
+	// EntGeneratedPackage is the ent generated package that holds the generated types
+	EntGeneratedPackage string
+}
 
 // Name returns the name of the plugin
 func (m *Plugin) Name() string {
@@ -31,6 +64,12 @@ func (m *Plugin) Name() string {
 type BulkResolverBuild struct {
 	// Objects is a list of objects to generate bulk resolvers for
 	Objects []Object
+	// ModelImport is the import path for the gqlgen model
+	ModelImport string
+	// EntImport is the ent generated package that holds the generated types
+	EntImport string
+	// ModelPackage is the package name for the gqlgen model
+	ModelPackage string
 }
 
 // Object is a struct to hold the object name for the bulk resolver
@@ -53,8 +92,16 @@ func (m *Plugin) GenerateCode(data *codegen.Data) error {
 // generateSingleFile generates the bulk resolver code, this is all done in a single file and
 // used by the resolvergen plugin for each bulk resolver
 func (m *Plugin) generateSingleFile(data codegen.Data) error {
+	modelPkg := data.Config.Model.Package
+	if modelPkg != "" {
+		modelPkg += "."
+	}
+
 	inputData := BulkResolverBuild{
-		Objects: []Object{},
+		Objects:      []Object{},
+		ModelImport:  m.ModelPackage,
+		EntImport:    m.EntGeneratedPackage,
+		ModelPackage: modelPkg,
 	}
 
 	for _, f := range data.Schema.Mutation.Fields {

--- a/resolvergen/crud.go
+++ b/resolvergen/crud.go
@@ -21,6 +21,7 @@ var templates embed.FS
 type crudResolver struct {
 	Field        *codegen.Field
 	AppendFields []string
+	ModelPackage string
 }
 
 // renderTemplate renders the template with the given name
@@ -32,6 +33,7 @@ func renderTemplate(templateName string, input *crudResolver) string {
 		"hasArgument":   hasArgument,
 		"hasOwnerField": hasOwnerField,
 		"reserveImport": gqltemplates.CurrentImports.Reserve,
+		"modelPackage":  modelPackage,
 	}).ParseFS(templates, "templates/"+templateName)
 	if err != nil {
 		panic(err)
@@ -46,55 +48,69 @@ func renderTemplate(templateName string, input *crudResolver) string {
 	return strings.Trim(code.String(), "\t \n")
 }
 
+func modelPackage(modelPackage string) string {
+	if modelPackage == "" {
+		return ""
+	}
+
+	return modelPackage + "."
+}
+
 // renderCreate renders the create template
-func renderCreate(field *codegen.Field) string {
+func renderCreate(field *codegen.Field, modelPackage string) string {
 	return renderTemplate("create.gotpl", &crudResolver{
-		Field: field,
+		Field:        field,
+		ModelPackage: modelPackage,
 	})
 }
 
 // renderUpdate renders the update template
-func renderUpdate(field *codegen.Field) string {
+func renderUpdate(field *codegen.Field, modelPackage string) string {
 	appendFields := getAppendFields(field)
 
 	cr := &crudResolver{
 		Field:        field,
 		AppendFields: appendFields,
+		ModelPackage: modelPackage,
 	}
 
 	return renderTemplate("update.gotpl", cr)
 }
 
 // renderDelete renders the delete template
-func renderDelete(field *codegen.Field) string {
+func renderDelete(field *codegen.Field, modelPackage string) string {
 	return renderTemplate("delete.gotpl", &crudResolver{
-		Field: field,
+		Field:        field,
+		ModelPackage: modelPackage,
 	})
 }
 
 // renderBulkUpload renders the bulk upload template
-func renderBulkUpload(field *codegen.Field) string {
+func renderBulkUpload(field *codegen.Field, modelPackage string) string {
 	return renderTemplate("upload.gotpl", &crudResolver{
-		Field: field,
+		Field:        field,
+		ModelPackage: modelPackage,
 	})
 }
 
 // renderBulk renders the bulk template
-func renderBulk(field *codegen.Field) string {
+func renderBulk(field *codegen.Field, modelPackage string) string {
 	return renderTemplate("bulk.gotpl", &crudResolver{
-		Field: field,
+		Field:        field,
+		ModelPackage: modelPackage,
 	})
 }
 
 // renderQuery renders the query template
-func renderQuery(field *codegen.Field) string {
+func renderQuery(field *codegen.Field, modelPackage string) string {
 	return renderTemplate("get.gotpl", &crudResolver{
-		Field: field,
+		Field:        field,
+		ModelPackage: modelPackage,
 	})
 }
 
 // renderList renders the list template
-func renderList(field *codegen.Field) string {
+func renderList(field *codegen.Field, modelPackage string) string {
 	return renderTemplate("list.gotpl", &crudResolver{
 		Field: field,
 	})

--- a/resolvergen/resolver.go
+++ b/resolvergen/resolver.go
@@ -55,8 +55,11 @@ func (r *ResolverPlugin) Implement(s string, f *codegen.Field) (val string) {
 
 // GenerateCode implements api.CodeGenerator
 func (r *ResolverPlugin) GenerateCode(data *codegen.Data) error {
-	// set the model package for the resolver
-	r.modelPackage = data.Config.Model.Package
+	// set the model package if it is different from the resolver package
+	if data.Config.Resolver.Package != data.Config.Model.Package {
+		r.modelPackage = data.Config.Model.Package
+	}
+
 	// use the default resolver plugin to generate the code
 	return r.Plugin.GenerateCode(data)
 }

--- a/resolvergen/resolver.go
+++ b/resolvergen/resolver.go
@@ -20,6 +20,8 @@ const (
 // ResolverPlugin is a gqlgen plugin to generate resolver functions
 type ResolverPlugin struct {
 	*resolvergen.Plugin
+
+	modelPackage string
 }
 
 // Name returns the name of the plugin
@@ -34,7 +36,7 @@ func New() *ResolverPlugin {
 }
 
 // Implement gqlgen api.ResolverImplementer
-func (r ResolverPlugin) Implement(s string, f *codegen.Field) (val string) {
+func (r *ResolverPlugin) Implement(s string, f *codegen.Field) (val string) {
 	// if the field has a custom resolver, use it
 	// panic is not a custom resolver so attempt to implement the field
 	if s != "" && !strings.Contains(s, "panic") {
@@ -43,16 +45,18 @@ func (r ResolverPlugin) Implement(s string, f *codegen.Field) (val string) {
 
 	switch {
 	case isMutation(f):
-		return mutationImplementer(f)
+		return mutationImplementer(f, r.modelPackage)
 	case isQuery(f):
-		return queryImplementer(f)
+		return queryImplementer(f, r.modelPackage)
 	default:
 		return fmt.Sprintf(defaultImplementation, f.GoFieldName, f.Name)
 	}
 }
 
 // GenerateCode implements api.CodeGenerator
-func (r ResolverPlugin) GenerateCode(data *codegen.Data) error {
+func (r *ResolverPlugin) GenerateCode(data *codegen.Data) error {
+	// set the model package for the resolver
+	r.modelPackage = data.Config.Model.Package
 	// use the default resolver plugin to generate the code
 	return r.Plugin.GenerateCode(data)
 }
@@ -68,30 +72,30 @@ func isQuery(f *codegen.Field) bool {
 }
 
 // mutationImplementer returns the implementation for the mutation
-func mutationImplementer(f *codegen.Field) string {
+func mutationImplementer(f *codegen.Field, modelPackage string) string {
 	switch crudType(f) {
 	case "BulkCSV":
-		return renderBulkUpload(f)
+		return renderBulkUpload(f, modelPackage)
 	case "Bulk":
-		return renderBulk(f)
+		return renderBulk(f, modelPackage)
 	case "Create":
-		return renderCreate(f)
+		return renderCreate(f, modelPackage)
 	case "Update":
-		return renderUpdate(f)
+		return renderUpdate(f, modelPackage)
 	case "Delete":
-		return renderDelete(f)
+		return renderDelete(f, modelPackage)
 	default:
 		return fmt.Sprintf(defaultImplementation, f.GoFieldName, f.Name)
 	}
 }
 
 // queryImplementer returns the implementation for the query
-func queryImplementer(f *codegen.Field) string {
+func queryImplementer(f *codegen.Field, modelPackage string) string {
 	if strings.Contains(f.TypeReference.Definition.Name, "Connection") {
-		return renderList(f)
+		return renderList(f, modelPackage)
 	}
 
-	return renderQuery(f)
+	return renderQuery(f, modelPackage)
 }
 
 // crudType returns the type of CRUD operation

--- a/resolvergen/templates/create.gotpl
+++ b/resolvergen/templates/create.gotpl
@@ -3,6 +3,7 @@
 
 {{ $entity := .Field.TypeReference.Definition.Name | getEntityName  -}}
 {{ $isOrgOwned := .Field | hasOwnerField  -}}
+{{ $modelPackage := .ModelPackage | modelPackage -}}
 
 {{- if $isOrgOwned }}
 // set the organization in the auth context if its not done for us
@@ -18,6 +19,6 @@ if err != nil {
 	return nil, parseRequestError(err, action{action: ActionCreate, object: "{{ $entity | toLower }}"})
 }
 
-return &{{ $entity }}CreatePayload{
+return &{{ $modelPackage }}{{ $entity }}CreatePayload{
 	{{ $entity }}: res,
 }, nil

--- a/resolvergen/templates/delete.gotpl
+++ b/resolvergen/templates/delete.gotpl
@@ -1,4 +1,5 @@
 {{ $entity := .Field.TypeReference.Definition.Name | getEntityName  -}}
+{{ $modelPackage := .ModelPackage | modelPackage -}}
 
 if err := withTransactionalMutation(ctx).{{ $entity }}.DeleteOneID(id).Exec(ctx); err != nil {
 	return nil, parseRequestError(err, action{action: ActionDelete, object: "{{ $entity | toLower }}"})
@@ -8,6 +9,6 @@ if err := generated.{{ $entity }}EdgeCleanup(ctx, id); err != nil {
 	return nil, newCascadeDeleteError(err)
 }
 
-return &{{ $entity }}DeletePayload{
+return &{{ $modelPackage} }{{ $entity }}DeletePayload{
 	DeletedID: id,
 }, nil

--- a/resolvergen/templates/update.gotpl
+++ b/resolvergen/templates/update.gotpl
@@ -3,6 +3,7 @@
 
 {{ $entity := .Field.TypeReference.Definition.Name | getEntityName  -}}
 {{ $isOrgOwned := .Field | hasOwnerField  -}}
+{{ $modelPackage := .ModelPackage | modelPackage -}}
 
 res, err := withTransactionalMutation(ctx).{{ $entity }}.Get(ctx, id)
 if err != nil {
@@ -26,6 +27,6 @@ if err != nil {
 	return nil, parseRequestError(err, action{action: ActionUpdate, object: "{{ $entity | toLower }}"})
 }
 
-return &{{ $entity }}UpdatePayload{
+return &{{ $modelPackage }}{{ $entity }}UpdatePayload{
 	{{ $entity }}: res,
 	}, nil

--- a/searchgen/search.go
+++ b/searchgen/search.go
@@ -107,17 +107,20 @@ func (r SearchPlugin) GenerateCode(data *codegen.Data) error {
 		return err
 	}
 
-	modelPkg := data.Config.Model.Package
-	if modelPkg != "" {
-		modelPkg += "."
-	}
+	inputData.ModelImport = r.ModelPackage
 
-	inputData.ModelPackage = modelPkg
+	// only add the model package if the import is not empty
+	if r.ModelPackage != "" {
+		modelPkg := data.Config.Model.Package
+		if modelPkg != "" {
+			modelPkg += "."
+		}
+
+		inputData.ModelPackage = modelPkg
+	}
 
 	// add the generated package name
 	inputData.EntImport = r.EntGeneratedPackage
-
-	inputData.ModelImport = r.ModelPackage
 
 	// generate the search helper
 	if err := genSearchHelper(data, inputData); err != nil {

--- a/searchgen/search.go
+++ b/searchgen/search.go
@@ -32,6 +32,7 @@ var resolverTemplate string
 // SearchPlugin is a gqlgen plugin to generate search functions
 type SearchPlugin struct {
 	EntGeneratedPackage string
+	ModelPackage        string
 }
 
 // Name returns the name of the plugin
@@ -47,14 +48,46 @@ func New(entPackage string) *SearchPlugin {
 	}
 }
 
+// Options is a function to set the options for the plugin
+type Options func(*SearchPlugin)
+
+// NewWithOptions returns a new search plugin with the given options
+func NewWithOptions(opts ...Options) *SearchPlugin {
+	r := &SearchPlugin{}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
+}
+
+// WithModelPackage sets the model package for the gqlgen model
+func WithModelPackage(modelPackage string) Options {
+	return func(p *SearchPlugin) {
+		p.ModelPackage = modelPackage
+	}
+}
+
+// WithEntGeneratedPackage sets the ent generated package for the gqlgen model
+func WithEntGeneratedPackage(entPackage string) Options {
+	return func(p *SearchPlugin) {
+		p.EntGeneratedPackage = entPackage
+	}
+}
+
 // SearchResolverBuild is a struct to hold the objects for the bulk resolver
 type SearchResolverBuild struct {
 	// Name of the search type
 	Name string
 	// Objects is a list of objects to generate bulk resolvers for
 	Objects []Object
-	// EntPackageName is the ent generated package that holds the generated types
-	EntPackageName string
+	// EntImport is the ent generated package that holds the generated types
+	EntImport string
+	// ModelImport is the package name for the gqlgen model
+	ModelImport string
+	// ModelPackage is the package name for the gqlgen model
+	ModelPackage string
 }
 
 // Object is a struct to hold the object name for the bulk resolver
@@ -74,8 +107,17 @@ func (r SearchPlugin) GenerateCode(data *codegen.Data) error {
 		return err
 	}
 
+	modelPkg := data.Config.Model.Package
+	if modelPkg != "" {
+		modelPkg += "."
+	}
+
+	inputData.ModelPackage = modelPkg
+
 	// add the generated package name
-	inputData.EntPackageName = r.EntGeneratedPackage
+	inputData.EntImport = r.EntGeneratedPackage
+
+	inputData.ModelImport = r.ModelPackage
 
 	// generate the search helper
 	if err := genSearchHelper(data, inputData); err != nil {

--- a/searchgen/templates/helpers.gotpl
+++ b/searchgen/templates/helpers.gotpl
@@ -1,13 +1,13 @@
 {{reserveImport "context" }}
 {{reserveImport "time" }}
 
-{{reserveImport $.EntPackageName "generated"}}
+{{reserveImport $.EntImport "generated"}}
 {{reserveImport "entgo.io/ent/dialect/sql"}}
 {{reserveImport "entgo.io/ent/dialect/sql/sqljson"}}
 
 import (
 {{- range $object := $.Objects }}
-    "{{ $.EntPackageName }}/{{ $object.Name | toLower }}"
+    "{{ $.EntImport }}/{{ $object.Name | toLower }}"
 {{- end }}
 )
 

--- a/searchgen/templates/resolver.gotpl
+++ b/searchgen/templates/resolver.gotpl
@@ -2,13 +2,21 @@
 
 {{ reserveImport "github.com/rs/zerolog/log" }}
 
-{{ reserveImport $.EntPackageName "generated"}}
+{{- if $.EntImport }}
+{{ reserveImport $.EntImport }}
+{{- end }}
+
+{{- if $.ModelImport }}
+{{ reserveImport $.ModelImport }}
+{{- end }}
+
+{{ $root := . }}
 
 // Search is the resolver for the search field.
 {{- if eq $.Name "Global" }}
-func (r *queryResolver) Search(ctx context.Context, query string) (*SearchResultConnection, error) {
+func (r *queryResolver) Search(ctx context.Context, query string) (*{{ .ModelPackage }}SearchResultConnection, error) {
 {{- else }}
-func (r *queryResolver) {{ $.Name }}Search(ctx context.Context, query string) (*SearchResultConnection, error) {
+func (r *queryResolver) {{ $.Name }}Search(ctx context.Context, query string) (*{{ .ModelPackage }}SearchResultConnection, error) {
 {{- end }}
 	if len(query) < 3 {
 		return nil, ErrSearchQueryTooShort
@@ -41,10 +49,10 @@ func (r *queryResolver) {{ $.Name }}Search(ctx context.Context, query string) (*
 	}
 
 	// return the results
-	return &SearchResultConnection{
-		Nodes: []SearchResult{
+	return &{{$root.ModelPackage}}SearchResultConnection{
+		Nodes: []{{$root.ModelPackage}}SearchResult{
             {{- range $object := $.Objects }}
-			{{ $object.Name }}SearchResult{
+			{{$root.ModelPackage}}{{ $object.Name }}SearchResult{
 				{{ $object.Name | toPlural }}: {{ $object.Name | toLower }}Results,
 			},
             {{- end }}
@@ -55,10 +63,10 @@ func (r *queryResolver) {{ $.Name }}Search(ctx context.Context, query string) (*
 {{- range $object := $.Objects }}
 
 {{- if eq $.Name "Global" }}
-func (r *queryResolver) {{ $object.Name }}Search(ctx context.Context, query string) (*{{ $object.Name }}SearchResult, error) {
+func (r *queryResolver) {{ $object.Name }}Search(ctx context.Context, query string) (*{{$root.ModelPackage}}{{ $object.Name }}SearchResult, error) {
 	{{ $object.Name | toLower }}Results, err := search{{ $object.Name | toPlural }}(ctx, query)
 {{- else }}
-func (r *queryResolver) Admin{{ $object.Name }}Search(ctx context.Context, query string) (*{{ $object.Name }}SearchResult, error) {
+func (r *queryResolver) Admin{{ $object.Name }}Search(ctx context.Context, query string) (*{{$root.ModelPackage}}{{ $object.Name }}SearchResult, error) {
 		{{ $object.Name | toLower }}Results, err := adminSearch{{ $object.Name | toPlural }}(ctx, query)
 {{- end}}
 
@@ -67,7 +75,7 @@ func (r *queryResolver) Admin{{ $object.Name }}Search(ctx context.Context, query
 	}
 
 	// return the results
-	return &{{ $object.Name }}SearchResult{
+	return &{{$root.ModelPackage}}{{ $object.Name }}SearchResult{
 		{{ $object.Name | toPlural }}: {{ $object.Name | toLower }}Results,
 	}, nil
 }


### PR DESCRIPTION
- removes hardcoded `openlane/core` packages
- allows for the `model` package for graphapi to be used, added to the templates
- **breaking changes** to now set the packages; the generated package will no longer be set to the openlane generate package

Allows for us to split the generated graphapi package: see https://github.com/theopenlane/core/pull/321