### PR TITLE
feat: add total count to results, only return fields with results

### DIFF
--- a/searchgen/templates/resolver.gotpl
+++ b/searchgen/templates/resolver.gotpl
@@ -49,14 +49,22 @@ func (r *queryResolver) {{ $.Name }}Search(ctx context.Context, query string) (*
 	}
 
 	// return the results
-	return &{{$root.ModelPackage}}SearchResultConnection{
-		Nodes: []{{$root.ModelPackage}}SearchResult{
-            {{- range $object := $.Objects }}
-			{{$root.ModelPackage}}{{ $object.Name }}SearchResult{
-				{{ $object.Name | toPlural }}: {{ $object.Name | toLower }}Results,
-			},
-            {{- end }}
-		},
+	var nodes []model.SearchResult
+	resultCount := 0
+
+	{{- range $object := $.Objects }}
+	if len({{ $object.Name | toLower }}Results) > 0 {
+		nodes = append(nodes, {{$root.ModelPackage}}{{ $object.Name }}SearchResult{
+			{{ $object.Name | toPlural }}: {{ $object.Name | toLower }}Results,
+		})
+
+		resultCount += len({{ $object.Name | toLower }}Results)
+	}
+	{{- end }}
+
+	return &model.SearchResultConnection{
+		TotalCount: resultCount,
+		Nodes: nodes,
 	}, nil
 }
 


### PR DESCRIPTION
- Adds the total number of results for the search
- Only returns type with results, e.g, if there are only programs, you just get those results back instead of a bunch of empty results as well 

```json
{
  "data": {
    "search": {
      "totalCount": 5,
      "nodes": [
        {
          "programs": [
            {
              "id": "01JG2R93TE54VP6WTAKC80YZH2",
              "name": "SOC2 - 2024",
              "__typename": "Program"
            },
            {
              "id": "01JG2R9460J0BY02VMS15783TA",
              "name": "SOC2 - 2024",
              "__typename": "Program"
            },
            {
              "id": "01JG2RA6BP2DM1VDZB7YFY5VMJ",
              "name": "SOC2 - 2025",
              "__typename": "Program"
            },
            {
              "id": "01JG2RA6DTSW7BMDTVWJS59PCW",
              "name": "SOC2 - 2025",
              "__typename": "Program"
            },
            {
              "id": "01JG2RA6JW5V1Q2KAJF246Z3C2",
              "name": "SOC2 - 2025",
              "__typename": "Program"
            }
          ],
          "__typename": "ProgramSearchResult"
        }
      ],
      "__typename": "SearchResultConnection"
    }
  }
}