### PR TITLE
Add create example CSV function generation to `bulkgen`

### DIFF
--- a/bulkgen/bulk.gotpl
+++ b/bulkgen/bulk.gotpl
@@ -1,5 +1,7 @@
 {{ reserveImport "context"  }}
-{{ reserveImport "errors"  }}
+{{ reserveImport "encoding/csv" }}
+{{ reserveImport "os" }}
+{{ reserveImport "fmt" }}
 
 {{- if $.EntImport }}
 {{ reserveImport $.EntImport }}
@@ -30,6 +32,41 @@ func (r *mutationResolver) bulkCreate{{ $object.Name }} (ctx context.Context, in
 	return &{{ $root.ModelPackage }}{{ $object.Name }}BulkCreatePayload{
 		{{ $object.PluralName }}: res,
 	}, nil
+}
+
+// generateSampleCSV{{ $object.Name }} generates a sample CSV file for {{ $object.Name }} based on the Create{{ $object.Name }}Input fields
+func generateSampleCSV{{ $object.Name }}() error {
+	headers := []string{
+		{{- range $field := $object.Fields }}
+		"{{ $field }}",
+		{{- end }}
+	}
+
+	file, err := os.Create(fmt.Sprintf("sample_{{ $object.Name | toLower }}.csv"))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	if err := writer.Write(headers); err != nil {
+		return err
+	}
+
+	// Add example row
+	exampleRow := []string{
+		{{- range $field := $object.Fields }}
+		"example_{{ $field | toLower }}",
+		{{- end }}
+	}
+	if err := writer.Write(exampleRow); err != nil {
+		return err
+	}
+
+	fmt.Printf("Sample CSV for {{ $object.Name }} created: sample_{{ $object.Name | toLower }}.csv\n")
+	return nil
 }
 
 {{ end }}

--- a/bulkgen/bulkresolvers.go
+++ b/bulkgen/bulkresolvers.go
@@ -10,7 +10,6 @@ import (
 	"github.com/99designs/gqlgen/plugin"
 	"github.com/gertd/go-pluralize"
 	"github.com/stoewer/go-strcase"
-	gqlast "github.com/vektah/gqlparser/v2/ast"
 )
 
 //go:embed bulk.gotpl
@@ -123,7 +122,7 @@ func (m *Plugin) generateSingleFile(data codegen.Data) error {
 			inputData.Objects = append(inputData.Objects, Object{
 				Name:       objectName,
 				PluralName: pluralize.NewClient().Plural(objectName),
-				Fields:     getCreateInputFields(f, data),
+				Fields:     getCreateInputFields(objectName, data),
 			})
 		}
 	}
@@ -143,12 +142,11 @@ func (m *Plugin) generateSingleFile(data codegen.Data) error {
 }
 
 // getCreateInputFields returns the list of fields available in the Create<object>Input
-func getCreateInputFields(field *gqlast.FieldDefinition, data codegen.Data) (inputFields []string) {
-	for _, arg := range field.Arguments {
-		if arg.Type.NamedType != "" && data.Schema.Types[arg.Type.NamedType].Kind == gqlast.InputObject {
-			for _, f := range data.Schema.Types[arg.Type.NamedType].Fields {
-				inputFields = append(inputFields, strcase.UpperCamelCase(f.Name))
-			}
+func getCreateInputFields(objectName string, data codegen.Data) (inputFields []string) {
+	inputTypeName := "Create" + objectName + "Input"
+	if inputType, ok := data.Schema.Types[inputTypeName]; ok {
+		for _, f := range inputType.Fields {
+			inputFields = append(inputFields, strcase.UpperCamelCase(f.Name))
 		}
 	}
 	return inputFields


### PR DESCRIPTION
Adds an appended `Fields` to the `bulkgen` plugin and `Object` struct, as well as an associated function to range over the fields used for create <object> input. Results in the following type of functions being created per object type, with the fields differing based on the object input fields:

```go
// generateSampleCSVTask generates a sample CSV file for Task based on the CreateTaskInput fields
func generateSampleCSVTask() error {
	headers := []string{
		"Tags",
		"Title",
		"Description",
		"Details",
		"Status",
		"Category",
		"Due",
		"Completed",
		"OwnerId",
		"AssignerId",
		"AssigneeId",
		"CommentIDs",
		"GroupIDs",
		"InternalPolicyIDs",
		"ProcedureIDs",
		"ControlIDs",
		"ControlObjectiveIDs",
		"SubcontrolIDs",
		"ProgramIDs",
		"EvidenceIDs",
	}

	file, err := os.Create(fmt.Sprintf("sample_task.csv"))
	if err != nil {
		return err
	}
	defer file.Close()

	writer := csv.NewWriter(file)
	defer writer.Flush()

	if err := writer.Write(headers); err != nil {
		return err
	}

	// Add example row
	exampleRow := []string{
		"example_tags",
		"example_title",
		"example_description",
		"example_details",
		"example_status",
		"example_category",
		"example_due",
		"example_completed",
		"example_ownerid",
		"example_assignerid",
		"example_assigneeid",
		"example_commentids",
		"example_groupids",
		"example_internalpolicyids",
		"example_procedureids",
		"example_controlids",
		"example_controlobjectiveids",
		"example_subcontrolids",
		"example_programids",
		"example_evidenceids",
	}
	if err := writer.Write(exampleRow); err != nil {
		return err
	}

	fmt.Printf("Sample CSV for Task created: sample_task.csv\n")
	return nil
}

```