### PR TITLE
refactor example csv output

### DIFF
--- a/bulkgen/bulk.gotpl
+++ b/bulkgen/bulk.gotpl
@@ -34,39 +34,4 @@ func (r *mutationResolver) bulkCreate{{ $object.Name }} (ctx context.Context, in
 	}, nil
 }
 
-// generateSampleCSV{{ $object.Name }} generates a sample CSV file for {{ $object.Name }} based on the Create{{ $object.Name }}Input fields
-func generateSampleCSV{{ $object.Name }}() error {
-	headers := []string{
-		{{- range $field := $object.Fields }}
-		"{{ $field }}",
-		{{- end }}
-	}
-
-	file, err := os.Create(fmt.Sprintf("sample_{{ $object.Name | toLower }}.csv"))
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	writer := csv.NewWriter(file)
-	defer writer.Flush()
-
-	if err := writer.Write(headers); err != nil {
-		return err
-	}
-
-	// Add example row
-	exampleRow := []string{
-		{{- range $field := $object.Fields }}
-		"example_{{ $field | toLower }}",
-		{{- end }}
-	}
-	if err := writer.Write(exampleRow); err != nil {
-		return err
-	}
-
-	fmt.Printf("Sample CSV for {{ $object.Name }} created: sample_{{ $object.Name | toLower }}.csv\n")
-	return nil
-}
-
 {{ end }}

--- a/bulkgen/bulkresolvers.go
+++ b/bulkgen/bulkresolvers.go
@@ -124,6 +124,16 @@ func (m *Plugin) generateSingleFile(data codegen.Data) error {
 		inputData.ModelPackage = modelPkg
 	}
 
+	if m.CSVOutputPath == "" {
+		m.CSVOutputPath = data.Config.Resolver.Dir() + "/csv"
+		// create the directory if it does not exist
+		if _, err := os.Stat(m.CSVOutputPath); os.IsNotExist(err) {
+			if err := os.MkdirAll(m.CSVOutputPath, os.ModePerm); err != nil {
+				return err
+			}
+		}
+	}
+
 	for _, f := range data.Schema.Mutation.Fields {
 		lowerName := strings.ToLower(f.Name)
 
@@ -140,15 +150,6 @@ func (m *Plugin) generateSingleFile(data codegen.Data) error {
 
 			inputData.Objects = append(inputData.Objects, object)
 
-			if m.CSVOutputPath == "" {
-				m.CSVOutputPath = fmt.Sprintf(data.Config.Resolver.Dir() + "/csv")
-				// create the directory if it does not exist
-				if _, err := os.Stat(m.CSVOutputPath); os.IsNotExist(err) {
-					if err := os.MkdirAll(m.CSVOutputPath, os.ModePerm); err != nil {
-						return err
-					}
-				}
-			}
 			// Generate and write the CSV file
 			if err := generateSampleCSV(object, m.CSVOutputPath); err != nil {
 				return err

--- a/bulkgen/bulkresolvers.go
+++ b/bulkgen/bulkresolvers.go
@@ -126,11 +126,12 @@ func (m *Plugin) generateSingleFile(data codegen.Data) error {
 
 	if m.CSVOutputPath == "" {
 		m.CSVOutputPath = data.Config.Resolver.Dir() + "/csv"
-		// create the directory if it does not exist
-		if _, err := os.Stat(m.CSVOutputPath); os.IsNotExist(err) {
-			if err := os.MkdirAll(m.CSVOutputPath, os.ModePerm); err != nil {
-				return err
-			}
+	}
+
+	// create the directory if it does not exist
+	if _, err := os.Stat(m.CSVOutputPath); os.IsNotExist(err) {
+		if err := os.MkdirAll(m.CSVOutputPath, os.ModePerm); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
Refactors the example CSV output so that instead of outputting template functions, the object is passed directly in and the CSV file is written as a part of the code generation when the plugin is executed.

```
Sample CSV for ActionPlan created: /Users/manderson/core/internal/graphapi/csv/sample_actionplan.csv
Sample CSV for APIToken created: /Users/manderson/core/internal/graphapi/csv/sample_apitoken.csv
Sample CSV for Contact created: /Users/manderson/core/internal/graphapi/csv/sample_contact.csv
Sample CSV for Control created: /Users/manderson/core/internal/graphapi/csv/sample_control.csv
Sample CSV for ControlImplementation created: /Users/manderson/core/internal/graphapi/csv/sample_controlimplementation.csv
Sample CSV for ControlObjective created: /Users/manderson/core/internal/graphapi/csv/sample_controlobjective.csv
Sample CSV for DocumentData created: /Users/manderson/core/internal/graphapi/csv/sample_documentdata.csv
Sample CSV for Entity created: /Users/manderson/core/internal/graphapi/csv/sample_entity.csv
Sample CSV for EntityType created: /Users/manderson/core/internal/graphapi/csv/sample_entitytype.csv
Sample CSV for Event created: /Users/manderson/core/internal/graphapi/csv/sample_event.csv
Sample CSV for Group created: /Users/manderson/core/internal/graphapi/csv/sample_group.csv
Sample CSV for GroupMembership created: /Users/manderson/core/internal/graphapi/csv/sample_groupmembership.csv
Sample CSV for GroupSetting created: /Users/manderson/core/internal/graphapi/csv/sample_groupsetting.csv
Sample CSV for Hush created: /Users/manderson/core/internal/graphapi/csv/sample_hush.csv
Sample CSV for Integration created: /Users/manderson/core/internal/graphapi/csv/sample_integration.csv
Sample CSV for InternalPolicy created: /Users/manderson/core/internal/graphapi/csv/sample_internalpolicy.csv
Sample CSV for Invite created: /Users/manderson/core/internal/graphapi/csv/sample_invite.csv
Sample CSV for MappedControl created: /Users/manderson/core/internal/graphapi/csv/sample_mappedcontrol.csv
Sample CSV for Narrative created: /Users/manderson/core/internal/graphapi/csv/sample_narrative.csv
Sample CSV for OrganizationSetting created: /Users/manderson/core/internal/graphapi/csv/sample_organizationsetting.csv
Sample CSV for OrgMembership created: /Users/manderson/core/internal/graphapi/csv/sample_orgmembership.csv
Sample CSV for Procedure created: /Users/manderson/core/internal/graphapi/csv/sample_procedure.csv
Sample CSV for Program created: /Users/manderson/core/internal/graphapi/csv/sample_program.csv
Sample CSV for ProgramMembership created: /Users/manderson/core/internal/graphapi/csv/sample_programmembership.csv
Sample CSV for Risk created: /Users/manderson/core/internal/graphapi/csv/sample_risk.csv
Sample CSV for Subcontrol created: /Users/manderson/core/internal/graphapi/csv/sample_subcontrol.csv
Sample CSV for Subscriber created: /Users/manderson/core/internal/graphapi/csv/sample_subscriber.csv
Sample CSV for Task created: /Users/manderson/core/internal/graphapi/csv/sample_task.csv
Sample CSV for Template created: /Users/manderson/core/internal/graphapi/csv/sample_template.csv
Sample CSV for UserSetting created: /Users/manderson/core/internal/graphapi/csv/sample_usersetting.csv
internal/graphapi/generate/generate.go: go run gen_gqlgen.go (generated, saved, noplugin, 24725ms)
```

Additionally a functional option parameter is added to be able to configure the output directory; if none is supplied, it nests a `csv` directory under the configured resolver directory