### PR TITLE
feat: add custom field resovlers for comments, update bulk to ensure owner

### DIFF
--- a/resolvergen/crud.go
+++ b/resolvergen/crud.go
@@ -14,7 +14,7 @@ import (
 	gqlast "github.com/vektah/gqlparser/v2/ast"
 )
 
-//go:embed templates/**.gotpl
+//go:embed templates/**.gotpl templates/**/**.gotpl
 var templates embed.FS
 
 // crudResolver is a struct to hold the field for the CRUD resolver
@@ -27,19 +27,29 @@ type crudResolver struct {
 	ModelPackage string
 	// EntImport is the ent import for the generated types
 	EntImport string
+	// IncludeCustomUpdateFields is a flag to include custom update fields
+	IncludeCustomUpdateFields bool
 }
 
 // renderTemplate renders the template with the given name
-func renderTemplate(templateName string, input *crudResolver) string {
+func renderTemplate(templateName string, input *crudResolver, childTemplates []string) string {
+	patterns := []string{"templates/" + templateName}
+
+	for _, child := range childTemplates {
+		patterns = append(patterns, "templates/"+child)
+	}
+
 	t, err := template.New(templateName).Funcs(template.FuncMap{
-		"getEntityName": getEntityName,
-		"toLower":       strings.ToLower,
-		"toLowerCamel":  strcase.LowerCamelCase,
-		"hasArgument":   hasArgument,
-		"hasOwnerField": hasOwnerField,
-		"reserveImport": gqltemplates.CurrentImports.Reserve,
-		"modelPackage":  modelPackage,
-	}).ParseFS(templates, "templates/"+templateName)
+		"getEntityName":           getEntityName,
+		"getInputObjectName":      getInputObjectName,
+		"toLower":                 strings.ToLower,
+		"toLowerCamel":            strcase.LowerCamelCase,
+		"hasArgument":             hasArgument,
+		"hasOwnerField":           hasOwnerField,
+		"reserveImport":           gqltemplates.CurrentImports.Reserve,
+		"modelPackage":            modelPackage,
+		"isCommentUpdateOnObject": isCommentUpdateOnObject,
+	}).ParseFS(templates, patterns...)
 	if err != nil {
 		panic(err)
 	}
@@ -64,10 +74,11 @@ func modelPackage(modelPackage string) string {
 // renderCreate renders the create template
 func (r *ResolverPlugin) renderCreate(field *codegen.Field) string {
 	return renderTemplate("create.gotpl", &crudResolver{
-		Field:        field,
-		ModelPackage: r.modelPackage,
-		EntImport:    r.entGeneratedPackage,
-	})
+		Field:                     field,
+		ModelPackage:              r.modelPackage,
+		EntImport:                 r.entGeneratedPackage,
+		IncludeCustomUpdateFields: r.includeCustomFields,
+	}, []string{})
 }
 
 // renderUpdate renders the update template
@@ -75,22 +86,24 @@ func (r *ResolverPlugin) renderUpdate(field *codegen.Field) string {
 	appendFields := getAppendFields(field)
 
 	cr := &crudResolver{
-		Field:        field,
-		AppendFields: appendFields,
-		ModelPackage: r.modelPackage,
-		EntImport:    r.entGeneratedPackage,
+		Field:                     field,
+		AppendFields:              appendFields,
+		ModelPackage:              r.modelPackage,
+		EntImport:                 r.entGeneratedPackage,
+		IncludeCustomUpdateFields: r.includeCustomFields,
 	}
 
-	return renderTemplate("update.gotpl", cr)
+	return renderTemplate("update.gotpl", cr, []string{"updatefields/*.gotpl"})
 }
 
 // renderDelete renders the delete template
 func (r *ResolverPlugin) renderDelete(field *codegen.Field) string {
 	return renderTemplate("delete.gotpl", &crudResolver{
-		Field:        field,
-		ModelPackage: r.modelPackage,
-		EntImport:    r.entGeneratedPackage,
-	})
+		Field:                     field,
+		ModelPackage:              r.modelPackage,
+		EntImport:                 r.entGeneratedPackage,
+		IncludeCustomUpdateFields: r.includeCustomFields,
+	}, []string{"deletefields/*.gotpl"})
 }
 
 // renderBulkUpload renders the bulk upload template
@@ -99,7 +112,7 @@ func (r *ResolverPlugin) renderBulkUpload(field *codegen.Field) string {
 		Field:        field,
 		ModelPackage: r.modelPackage,
 		EntImport:    r.entGeneratedPackage,
-	})
+	}, []string{})
 }
 
 // renderBulk renders the bulk template
@@ -108,7 +121,7 @@ func (r *ResolverPlugin) renderBulk(field *codegen.Field) string {
 		Field:        field,
 		ModelPackage: r.modelPackage,
 		EntImport:    r.entGeneratedPackage,
-	})
+	}, []string{})
 }
 
 // renderQuery renders the query template
@@ -117,7 +130,7 @@ func (r *ResolverPlugin) renderQuery(field *codegen.Field) string {
 		Field:        field,
 		ModelPackage: r.modelPackage,
 		EntImport:    r.entGeneratedPackage,
-	})
+	}, []string{})
 }
 
 // renderList renders the list template
@@ -125,12 +138,13 @@ func (r *ResolverPlugin) renderList(field *codegen.Field) string {
 	return renderTemplate("list.gotpl", &crudResolver{
 		Field:     field,
 		EntImport: r.entGeneratedPackage,
-	})
+	}, []string{})
 }
 
 const (
 	CreateOperation  = "Create"
 	UpdateOperation  = "Update"
+	AddOperation     = "Add"
 	DeleteOperation  = "Delete"
 	InputObject      = "Input"
 	BulkOperation    = "Bulk"
@@ -212,4 +226,23 @@ func getAppendFields(field *codegen.Field) (appendFields []string) {
 	}
 
 	return
+}
+
+// isCommentUpdateOnObject checks if the field is of the format "Update<Something>Comment"
+func isCommentUpdateOnObject(field string) bool {
+	if strings.Contains(field, UpdateOperation) && strings.Contains(field, "Comment") {
+		return true
+	}
+
+	return false
+}
+
+// getInputObjectName returns the input object name by stripping the CRUD operation from the resolver name
+// for example UpdateTaskInput will return Task
+func getInputObjectName(objectName string) string {
+	// replace all operations
+	objectName = strings.ReplaceAll(objectName, CreateOperation, "")
+	objectName = strings.ReplaceAll(objectName, UpdateOperation, "")
+
+	return strings.ReplaceAll(objectName, InputObject, "")
 }

--- a/resolvergen/crud.go
+++ b/resolvergen/crud.go
@@ -187,6 +187,10 @@ func hasOwnerField(field *codegen.Field) bool {
 		// check the input of the create, instead of the update since its immutable
 		checkFieldName := strings.Replace(field.Name, "update", "create", 1)
 
+		// remove the Bulk and BulkCSV from fields
+		checkFieldName = strings.ReplaceAll(checkFieldName, BulkOperation, "")
+		checkFieldName = strings.ReplaceAll(checkFieldName, CSVOperation, "")
+
 		if field.Object.HasField(checkFieldName) {
 			for _, obj := range field.Object.Fields {
 				if obj.Name == checkFieldName {

--- a/resolvergen/crud.go
+++ b/resolvergen/crud.go
@@ -27,7 +27,7 @@ type crudResolver struct {
 	ModelPackage string
 	// EntImport is the ent import for the generated types
 	EntImport string
-	// IncludeCustomUpdateFields is a flag to include custom update fields
+	// IncludeCustomUpdateFields is a flag to include custom fields
 	IncludeCustomUpdateFields bool
 }
 

--- a/resolvergen/crud_test.go
+++ b/resolvergen/crud_test.go
@@ -98,3 +98,93 @@ func TestGetEntityName(t *testing.T) {
 		})
 	}
 }
+func TestIsCommentUpdateOnObject(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "is comment update",
+			input:    "UpdateComment",
+			expected: true,
+		},
+		{
+			name:     "update task comment",
+			input:    "UpdateTaskComment",
+			expected: true,
+		},
+		{
+			name:     "is not comment update",
+			input:    "UpdatePost",
+			expected: false,
+		},
+		{
+			name:     "contains comment but not update",
+			input:    "CreateComment",
+			expected: false,
+		},
+		{
+			name:     "contains update but not comment",
+			input:    "UpdateUser",
+			expected: false,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := isCommentUpdateOnObject(tc.input)
+			assert.Equal(t, tc.expected, res)
+		})
+	}
+}
+func TestGetInputObjectName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "strip CreateOperation",
+			input:    "CreateUserInput",
+			expected: "User",
+		},
+		{
+			name:     "strip UpdateOperation",
+			input:    "UpdatePostInput",
+			expected: "Post",
+		},
+		{
+			name:     "strip InputObject",
+			input:    "UserInput",
+			expected: "User",
+		},
+		{
+			name:     "strip Create and InputObject",
+			input:    "CreateProductInput",
+			expected: "Product",
+		},
+		{
+			name:     "strip Update and InputObject",
+			input:    "UpdateOrderInput",
+			expected: "Order",
+		},
+		{
+			name:     "no strip",
+			input:    "User",
+			expected: "User",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := getInputObjectName(tc.input)
+			assert.Equal(t, tc.expected, res)
+		})
+	}
+}

--- a/resolvergen/crud_test.go
+++ b/resolvergen/crud_test.go
@@ -150,21 +150,6 @@ func TestGetInputObjectName(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "strip CreateOperation",
-			input:    "CreateUserInput",
-			expected: "User",
-		},
-		{
-			name:     "strip UpdateOperation",
-			input:    "UpdatePostInput",
-			expected: "Post",
-		},
-		{
-			name:     "strip InputObject",
-			input:    "UserInput",
-			expected: "User",
-		},
-		{
 			name:     "strip Create and InputObject",
 			input:    "CreateProductInput",
 			expected: "Product",
@@ -173,6 +158,11 @@ func TestGetInputObjectName(t *testing.T) {
 			name:     "strip Update and InputObject",
 			input:    "UpdateOrderInput",
 			expected: "Order",
+		},
+		{
+			name:     "strip InputObject",
+			input:    "UserInput",
+			expected: "User",
 		},
 		{
 			name:     "no strip",

--- a/resolvergen/resolver.go
+++ b/resolvergen/resolver.go
@@ -158,7 +158,9 @@ func crudType(f *codegen.Field) string {
 		return BulkOperation
 	case strings.Contains(f.GoFieldName, CreateOperation):
 		return CreateOperation
-	case strings.Contains(f.GoFieldName, UpdateOperation), strings.Contains(f.GoFieldName, AddOperation):
+	case strings.Contains(f.GoFieldName, UpdateOperation),
+		// also include Add, which is an update to a parent object with a child object (e.g. add comment to a task)
+		strings.Contains(f.GoFieldName, AddOperation):
 		return UpdateOperation
 	case strings.Contains(f.GoFieldName, DeleteOperation):
 		return DeleteOperation

--- a/resolvergen/templates/bulk.gotpl
+++ b/resolvergen/templates/bulk.gotpl
@@ -5,7 +5,7 @@ if len(input) == 0 {
     return nil, rout.NewMissingRequiredFieldError("input")
 }
 
-{{- if $ }}
+{{ if $isOrgOwned }}
 // set the organization in the auth context if its not done for us
 // this will choose the first input OwnerID when using a personal access token
 if err := setOrganizationInAuthContextBulkRequest(ctx, input); err != nil {

--- a/resolvergen/templates/bulk.gotpl
+++ b/resolvergen/templates/bulk.gotpl
@@ -1,4 +1,19 @@
 {{ $entity := .Field.TypeReference.Definition.Name | getEntityName  -}}
+{{ $isOrgOwned := .Field | hasOwnerField  -}}
+
+if len(input) == 0 {
+    return nil, rout.NewMissingRequiredFieldError("input")
+}
+
+{{- if $ }}
+// set the organization in the auth context if its not done for us
+// this will choose the first input OwnerID when using a personal access token
+if err := setOrganizationInAuthContextBulkRequest(ctx, input); err != nil {
+    log.Error().Err(err).Msg("failed to set organization in auth context")
+
+    return nil, rout.NewMissingRequiredFieldError("owner_id")
+}
+{{- end }}
 
 // grab preloads and set max result limits
 graphutils.GetPreloads(ctx, r.maxResultLimit)

--- a/resolvergen/templates/create.gotpl
+++ b/resolvergen/templates/create.gotpl
@@ -8,7 +8,7 @@
 // grab preloads and set max result limits
 graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-{{- if $isOrgOwned }}
+{{ if $isOrgOwned }}
 // set the organization in the auth context if its not done for us
 if err := setOrganizationInAuthContext(ctx, input.OwnerID); err != nil {
 	log.Error().Err(err).Msg("failed to set organization in auth context")

--- a/resolvergen/templates/delete.gotpl
+++ b/resolvergen/templates/delete.gotpl
@@ -1,14 +1,16 @@
-{{ $entity := .Field.TypeReference.Definition.Name | getEntityName  -}}
-{{ $modelPackage := .ModelPackage | modelPackage -}}
+{{/* Include all custom fields */}}
+{{- if $.IncludeCustomUpdateFields }}
+	{{- if eq .Field.GoFieldName "DeleteComment" }}
+		{{ template "deletecomment" . }}
 
-if err := withTransactionalMutation(ctx).{{ $entity }}.DeleteOneID(id).Exec(ctx); err != nil {
-	return nil, parseRequestError(err, action{action: ActionDelete, object: "{{ $entity | toLower }}"})
-}
+	{{- else }}
 
-if err := generated.{{ $entity }}EdgeCleanup(ctx, id); err != nil {
-	return nil, newCascadeDeleteError(err)
-}
+	{{ template "baseResolver" . }}
 
-return &{{ $modelPackage }}{{ $entity }}DeletePayload{
-	DeletedID: id,
-}, nil
+	{{- end }}
+
+{{- else }}
+	{{/* Only include base resolver template */}}
+
+	{{ template "baseResolver" . }}
+{{- end }}

--- a/resolvergen/templates/deletefields/comments.gotpl
+++ b/resolvergen/templates/deletefields/comments.gotpl
@@ -1,0 +1,11 @@
+{{ define "deletecomment" }}
+if data == nil {
+    return nil
+}
+
+if err := withTransactionalMutation(ctx).Note.DeleteOneID(*data).Exec(ctx); err != nil {
+    return parseRequestError(err, action{action: ActionDelete, object: "comment"})
+}
+
+return nil
+{{ end }}

--- a/resolvergen/templates/deletefields/deleteresolver.gotpl
+++ b/resolvergen/templates/deletefields/deleteresolver.gotpl
@@ -1,0 +1,16 @@
+{{ define "baseResolver" }}
+{{ $entity := .Field.TypeReference.Definition.Name | getEntityName  -}}
+{{ $modelPackage := .ModelPackage | modelPackage -}}
+
+if err := withTransactionalMutation(ctx).{{ $entity }}.DeleteOneID(id).Exec(ctx); err != nil {
+	return nil, parseRequestError(err, action{action: ActionDelete, object: "{{ $entity | toLower }}"})
+}
+
+if err := generated.{{ $entity }}EdgeCleanup(ctx, id); err != nil {
+	return nil, newCascadeDeleteError(err)
+}
+
+return &{{ $modelPackage }}{{ $entity }}DeletePayload{
+	DeletedID: id,
+}, nil
+{{ end }}

--- a/resolvergen/templates/update.gotpl
+++ b/resolvergen/templates/update.gotpl
@@ -1,47 +1,28 @@
 {{ reserveImport "github.com/theopenlane/utils/rout" }}
 {{ reserveImport "github.com/rs/zerolog/log" }}
 
-{{ $entity := .Field.TypeReference.Definition.Name | getEntityName  -}}
-{{ $isOrgOwned := .Field | hasOwnerField  -}}
-{{ $modelPackage := .ModelPackage | modelPackage -}}
+{{/* Include all custom fields */}}
+{{- if $.IncludeCustomUpdateFields }}
+	{{- if eq .Field.GoFieldName "RevisionBump" }}
+		{{ template "revisionBump" . }}
 
-{{- if eq .Field.GoFieldName "RevisionBump" }}
-	if data == nil {
-		return nil
-	}
+	{{- else if eq .Field.GoFieldName "AddComment" }}
+		{{ template "addcomment" . }}
 
-	models.WithVersionBumpRequestContext(ctx, data)
+	{{- else if isCommentUpdateOnObject .Field.GoFieldName }}
+		{{ template "updatecomment" . }}
 
-	return nil
+	{{- else if eq .Field.GoFieldName "DeleteComment" }}
+		{{ template "deletecomment" . }}
+
+	{{- else }}
+
+	{{ template "baseResolver" . }}
+
+	{{- end }}
+
 {{- else }}
+	{{/* Only include base resolver template */}}
 
-// grab preloads and set max result limits
-graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-res, err := withTransactionalMutation(ctx).{{ $entity }}.Get(ctx, id)
-if err != nil {
-	return nil, parseRequestError(err, action{action: ActionUpdate, object: "{{ $entity | toLower }}"})
-}
-
-{{- if $isOrgOwned }}
-// set the organization in the auth context if its not done for us
-if err := setOrganizationInAuthContext(ctx, &res.OwnerID); err != nil {
-	log.Error().Err(err).Msg("failed to set organization in auth context")
-
-	return nil, rout.ErrPermissionDenied
-}
-{{- end }}
-
-// setup update request
-req := res.Update().SetInput(input){{- range $appendField := .AppendFields }}.{{ $appendField }}(input.{{ $appendField }}){{- end }}
-
-res, err = req.Save(ctx)
-if err != nil {
-	return nil, parseRequestError(err, action{action: ActionUpdate, object: "{{ $entity | toLower }}"})
-}
-
-return &{{ $modelPackage }}{{ $entity }}UpdatePayload{
-	{{ $entity }}: res,
-	}, nil
-
+	{{ template "baseResolver" . }}
 {{- end }}

--- a/resolvergen/templates/updatefields/comments.gotpl
+++ b/resolvergen/templates/updatefields/comments.gotpl
@@ -1,0 +1,73 @@
+{{ define "addcomment" }}
+{{/* We need the input type, not the entity because its creating a note under another object type */}}
+{{ $inputType := .Field.Object.Name | getInputObjectName}}
+
+if data == nil {
+    return nil
+}
+
+// set the organization in the auth context if its not done for us
+if err := setOrganizationInAuthContext(ctx, data.OwnerID); err != nil {
+    log.Error().Err(err).Msg("failed to set organization in auth context")
+
+    return rout.NewMissingRequiredFieldError("owner_id")
+}
+
+data.{{ $inputType }}ID = graphutils.GetStringInputVariableByName(ctx, "id")
+if data.{{ $inputType }}ID == nil {
+    return newNotFoundError("{{ $inputType | toLower }}")
+}
+
+if err := withTransactionalMutation(ctx).Note.Create().SetInput(*data).Exec(ctx); err != nil {
+    return parseRequestError(err, action{action: ActionCreate, object: "comment"})
+}
+
+return nil
+{{ end }}
+
+{{ define "updatecomment" }}
+
+{{/* entity on update is the parent object (e.g. Task) not the input so we can safely use entity here like other updates */}}
+{{ $entity := .Field.TypeReference.Definition.Name | getEntityName  -}}
+
+{{ $import := print $.EntImport "/" $entity | toLower }}
+{{ reserveImport $import}}
+
+res, err := withTransactionalMutation(ctx).Note.Get(ctx, id)
+if err != nil {
+    return nil, parseRequestError(err, action{action: ActionUpdate, object: "{{ $entity | toLower}}"})
+}
+
+// setup update request
+req := res.Update().SetInput(input)
+
+if err = req.Exec(ctx); err != nil {
+    return nil, parseRequestError(err, action{action: ActionUpdate, object: "{{ $entity | toLower}}"})
+}
+
+// grab preloads and set max result limits
+graphutils.GetPreloads(ctx, r.maxResultLimit)
+
+objectRes, err := withTransactionalMutation(ctx).{{ $entity }}.Query().Where({{ $entity | toLower}}.HasCommentsWith(note.ID(id))).Only(ctx)
+if err != nil {
+    return nil, parseRequestError(err, action{action: ActionUpdate, object: "{{ $entity | toLower}}"})
+}
+
+return &model.{{ $entity }}UpdatePayload{
+    {{ $entity }}: objectRes,
+}, nil
+{{ end }}
+
+{{ define "deletecomment" }}
+{{ $entity := .Field.TypeReference.Definition.Name | getEntityName  -}}
+
+if data == nil {
+    return nil
+}
+
+if err := withTransactionalMutation(ctx).{{ $entity }}.DeleteOneID(*data).Exec(ctx); err != nil {
+    return parseRequestError(err, action{action: ActionDelete, object: "{{ $entity | toLower }}"})
+}
+
+return nil
+{{ end }}

--- a/resolvergen/templates/updatefields/revision.gotpl
+++ b/resolvergen/templates/updatefields/revision.gotpl
@@ -1,0 +1,9 @@
+{{ define "revisionBump" }}
+if data == nil {
+    return nil
+}
+
+models.WithVersionBumpRequestContext(ctx, data)
+
+return nil
+{{ end }}

--- a/resolvergen/templates/updatefields/updateresolver.gotpl
+++ b/resolvergen/templates/updatefields/updateresolver.gotpl
@@ -12,7 +12,7 @@ if err != nil {
 	return nil, parseRequestError(err, action{action: ActionUpdate, object: "{{ $entity | toLower }}"})
 }
 
-{{- if $isOrgOwned }}
+{{ if $isOrgOwned }}
 // set the organization in the auth context if its not done for us
 if err := setOrganizationInAuthContext(ctx, &res.OwnerID); err != nil {
 	log.Error().Err(err).Msg("failed to set organization in auth context")

--- a/resolvergen/templates/updatefields/updateresolver.gotpl
+++ b/resolvergen/templates/updatefields/updateresolver.gotpl
@@ -1,0 +1,35 @@
+{{ define "baseResolver" }}
+
+{{ $entity := .Field.TypeReference.Definition.Name | getEntityName  -}}
+{{ $isOrgOwned := .Field | hasOwnerField  -}}
+{{ $modelPackage := .ModelPackage | modelPackage -}}
+
+// grab preloads and set max result limits
+graphutils.GetPreloads(ctx, r.maxResultLimit)
+
+res, err := withTransactionalMutation(ctx).{{ $entity }}.Get(ctx, id)
+if err != nil {
+	return nil, parseRequestError(err, action{action: ActionUpdate, object: "{{ $entity | toLower }}"})
+}
+
+{{- if $isOrgOwned }}
+// set the organization in the auth context if its not done for us
+if err := setOrganizationInAuthContext(ctx, &res.OwnerID); err != nil {
+	log.Error().Err(err).Msg("failed to set organization in auth context")
+
+	return nil, rout.ErrPermissionDenied
+}
+{{- end }}
+
+// setup update request
+req := res.Update().SetInput(input){{- range $appendField := .AppendFields }}.{{ $appendField }}(input.{{ $appendField }}){{- end }}
+
+res, err = req.Save(ctx)
+if err != nil {
+	return nil, parseRequestError(err, action{action: ActionUpdate, object: "{{ $entity | toLower }}"})
+}
+
+return &{{ $modelPackage }}{{ $entity }}UpdatePayload{
+	{{ $entity }}: res,
+	}, nil
+{{ end }}

--- a/resolvergen/templates/upload.gotpl
+++ b/resolvergen/templates/upload.gotpl
@@ -1,6 +1,7 @@
 {{ reserveImport "github.com/rs/zerolog/log" }}
 
 {{ $entity := .Field.TypeReference.Definition.Name | getEntityName  -}}
+{{ $isOrgOwned := .Field | hasOwnerField  -}}
 
 // grab preloads and set max result limits
 graphutils.GetPreloads(ctx, r.maxResultLimit)
@@ -11,5 +12,19 @@ if err != nil {
 
 	return nil, err
 }
+
+if len(data) == 0 {
+    return nil, rout.NewMissingRequiredFieldError("input")
+}
+
+{{- if $isOrgOwned }}
+// set the organization in the auth context if its not done for us
+// this will choose the first input OwnerID when using a personal access token
+if err := setOrganizationInAuthContextBulkRequest(ctx, data); err != nil {
+    log.Error().Err(err).Msg("failed to set organization in auth context")
+
+    return nil, rout.NewMissingRequiredFieldError("owner_id")
+}
+{{- end }}
 
 return r.bulkCreate{{ $entity }}(ctx, data)

--- a/resolvergen/templates/upload.gotpl
+++ b/resolvergen/templates/upload.gotpl
@@ -17,7 +17,7 @@ if len(data) == 0 {
     return nil, rout.NewMissingRequiredFieldError("input")
 }
 
-{{- if $isOrgOwned }}
+{{ if $isOrgOwned }}
 // set the organization in the auth context if its not done for us
 // this will choose the first input OwnerID when using a personal access token
 if err := setOrganizationInAuthContextBulkRequest(ctx, data); err != nil {


### PR DESCRIPTION
- Adds resolvers for comments, which should be able to be reused for all schemas we add comments (notes) to; instead of manually updating the resolvers each time
- Fixes issue with bulk creation + using a personal access token - verifies the owner is in the input - sets the org in the context (already used for single creation)