### PR TITLE
remove preloads functions, adding to middleware instead

### DIFF
--- a/resolvergen/templates/bulk.gotpl
+++ b/resolvergen/templates/bulk.gotpl
@@ -15,7 +15,4 @@ if err := setOrganizationInAuthContextBulkRequest(ctx, input); err != nil {
 }
 {{- end }}
 
-// grab preloads to set max result limits
-graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 return r.bulkCreate{{ $entity }}(ctx, input)

--- a/resolvergen/templates/create.gotpl
+++ b/resolvergen/templates/create.gotpl
@@ -5,9 +5,6 @@
 {{ $isOrgOwned := .Field | hasOwnerField  -}}
 {{ $modelPackage := .ModelPackage | modelPackage -}}
 
-// grab preloads to set max result limits
-graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 {{ if $isOrgOwned }}
 // set the organization in the auth context if its not done for us
 if err := setOrganizationInAuthContext(ctx, input.OwnerID); err != nil {

--- a/resolvergen/templates/get.gotpl
+++ b/resolvergen/templates/get.gotpl
@@ -22,8 +22,6 @@ return res, nil
 {{ $import := print $.EntImport "/" $entity | toLower }}
 {{ reserveImport $import}}
 
-graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 query, err := withTransactionalMutation(ctx).{{ $entity }}.Query().Where({{ $entity | toLower }}.ID(id)).CollectFields(ctx)
 if err != nil {
 	return nil, parseRequestError(err, action{action: ActionGet, object: "{{ $entity | toLower }}"})

--- a/resolvergen/templates/list.gotpl
+++ b/resolvergen/templates/list.gotpl
@@ -8,9 +8,6 @@
 {{ $hasOrderBy := hasArgument "orderBy" .Field.FieldDefinition.Arguments }}
 {{ $hasWhere := hasArgument "where" .Field.FieldDefinition.Arguments }}
 
-// grab preloads to set max result limits
-graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 {{ if and $hasFirst $hasLast }}
 // set page limit if nothing was set
 first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)

--- a/resolvergen/templates/updatefields/comments.gotpl
+++ b/resolvergen/templates/updatefields/comments.gotpl
@@ -45,9 +45,6 @@ if err = req.Exec(ctx); err != nil {
     return nil, parseRequestError(err, action{action: ActionUpdate, object: "{{ $entity | toLower}}"})
 }
 
-// grab preloads to set max result limits
-graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 objectRes, err := withTransactionalMutation(ctx).{{ $entity }}.Query().Where({{ $entity | toLower}}.HasCommentsWith(note.ID(id))).Only(ctx)
 if err != nil {
     return nil, parseRequestError(err, action{action: ActionUpdate, object: "{{ $entity | toLower}}"})

--- a/resolvergen/templates/updatefields/updateresolver.gotpl
+++ b/resolvergen/templates/updatefields/updateresolver.gotpl
@@ -4,9 +4,6 @@
 {{ $isOrgOwned := .Field | hasOwnerField  -}}
 {{ $modelPackage := .ModelPackage | modelPackage -}}
 
-// grab preloads to set max result limits
-graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 res, err := withTransactionalMutation(ctx).{{ $entity }}.Get(ctx, id)
 if err != nil {
 	return nil, parseRequestError(err, action{action: ActionUpdate, object: "{{ $entity | toLower }}"})

--- a/resolvergen/templates/upload.gotpl
+++ b/resolvergen/templates/upload.gotpl
@@ -3,9 +3,6 @@
 {{ $entity := .Field.TypeReference.Definition.Name | getEntityName  -}}
 {{ $isOrgOwned := .Field | hasOwnerField  -}}
 
-// grab preloads to set max result limits
-graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 data, err := unmarshalBulkData[generated.Create{{ $entity }}Input](input)
 if err != nil {
 	log.Error().Err(err).Msg("failed to unmarshal bulk data")


### PR DESCRIPTION
now that we don't need the fields themselves, we can call this once in middleware instead of in all resolver functions. 