### PR TITLE
feat: add default order by

### DIFF
--- a/resolvergen/crud.go
+++ b/resolvergen/crud.go
@@ -171,11 +171,7 @@ func getEntityName(name string) string {
 
 // hasArgument checks if the argument is present in the list of arguments
 func hasArgument(arg string, args gqlast.ArgumentDefinitionList) bool {
-	if args.ForName(arg) != nil {
-		return true
-	}
-
-	return false
+	return args.ForName(arg) != nil
 }
 
 func isListType(arg string, args gqlast.ArgumentDefinitionList) bool {

--- a/resolvergen/crud.go
+++ b/resolvergen/crud.go
@@ -45,6 +45,7 @@ func renderTemplate(templateName string, input *crudResolver, childTemplates []s
 		"toLower":                 strings.ToLower,
 		"toLowerCamel":            strcase.LowerCamelCase,
 		"hasArgument":             hasArgument,
+		"isListType":              isListType,
 		"hasOwnerField":           hasOwnerField,
 		"reserveImport":           gqltemplates.CurrentImports.Reserve,
 		"modelPackage":            modelPackage,
@@ -170,13 +171,20 @@ func getEntityName(name string) string {
 
 // hasArgument checks if the argument is present in the list of arguments
 func hasArgument(arg string, args gqlast.ArgumentDefinitionList) bool {
-	for _, a := range args {
-		if a.Name == arg {
-			return true
-		}
+	if args.ForName(arg) != nil {
+		return true
 	}
 
 	return false
+}
+
+func isListType(arg string, args gqlast.ArgumentDefinitionList) bool {
+	a := args.ForName(arg)
+	if a == nil {
+		return false
+	}
+
+	return a.Type.Elem != nil
 }
 
 // hasOwnerField checks if the field has an owner field in the input arguments

--- a/resolvergen/crud_test.go
+++ b/resolvergen/crud_test.go
@@ -178,3 +178,75 @@ func TestGetInputObjectName(t *testing.T) {
 		})
 	}
 }
+
+func TestIsListType(t *testing.T) {
+	testCases := []struct {
+		name     string
+		argName  string
+		args     ast.ArgumentDefinitionList
+		expected bool
+	}{
+		{
+			name:    "argument is list type",
+			argName: "ids",
+			args: ast.ArgumentDefinitionList{
+				{
+					Name: "ids",
+					Type: ast.NonNullListType(ast.NamedType("ID", nil), nil),
+				},
+			},
+			expected: true,
+		},
+		{
+			name:    "argument is not list type",
+			argName: "name",
+			args: ast.ArgumentDefinitionList{
+				{
+					Name: "name",
+					Type: ast.NamedType("String", nil),
+				},
+			},
+			expected: false,
+		},
+		{
+			name:    "argument not found",
+			argName: "missing",
+			args: ast.ArgumentDefinitionList{
+				{
+					Name: "ids",
+					Type: ast.NonNullListType(ast.NamedType("ID", nil), nil),
+				},
+			},
+			expected: false,
+		},
+		{
+			name:    "argument is list of objects",
+			argName: "items",
+			args: ast.ArgumentDefinitionList{
+				{
+					Name: "items",
+					Type: ast.ListType(ast.NamedType("Item", nil), nil),
+				},
+			},
+			expected: true,
+		},
+		{
+			name:    "argument is non-list type",
+			argName: "count",
+			args: ast.ArgumentDefinitionList{
+				{
+					Name: "count",
+					Type: ast.NonNullNamedType("Int", nil),
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := isListType(tc.argName, tc.args)
+			assert.Equal(t, tc.expected, res)
+		})
+	}
+}

--- a/resolvergen/templates/list.gotpl
+++ b/resolvergen/templates/list.gotpl
@@ -6,6 +6,7 @@
 {{ $hasBefore := hasArgument "before" .Field.FieldDefinition.Arguments }}
 {{ $hasLast := hasArgument "last" .Field.FieldDefinition.Arguments }}
 {{ $hasOrderBy := hasArgument "orderBy" .Field.FieldDefinition.Arguments }}
+{{ $orderByIsList := isListType "orderBy" .Field.FieldDefinition.Arguments }}
 {{ $hasWhere := hasArgument "where" .Field.FieldDefinition.Arguments }}
 
 {{ if and $hasFirst $hasLast }}
@@ -15,11 +16,17 @@ first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
 {{ if $hasOrderBy }}
 if orderBy == nil {
+	{{- if $orderByIsList }}
 	orderBy = []*generated.{{ $entity }}Order{
 		{
 			Field:     generated.{{ $entity }}OrderFieldCreatedAt,
 			Direction: entgql.OrderDirectionDesc,
 		},
+	{{- else }}
+	orderBy = &generated.{{ $entity }}Order{
+		Field: generated.{{ $entity }}OrderFieldCreatedAt,
+		Direction: entgql.OrderDirectionDesc,
+	{{- end }}
 	}
 }
 {{- end }}

--- a/resolvergen/templates/list.gotpl
+++ b/resolvergen/templates/list.gotpl
@@ -13,6 +13,17 @@
 first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 {{- end }}
 
+{{ if $hasOrderBy }}
+if orderBy == nil {
+	orderBy = []*generated.{{ $entity }}Order{
+		{
+			Field:     generated.{{ $entity }}OrderFieldCreatedAt,
+			Direction: entgql.OrderDirectionDesc,
+		},
+	}
+}
+{{- end }}
+
 query, err :=  withTransactionalMutation(ctx).{{ $entity }}.Query().CollectFields(ctx)
 if err != nil {
 	return nil, parseRequestError(err, action{action: ActionGet, object: "{{ $entity | toLower }}"})


### PR DESCRIPTION
Adds a default order by field to all list resovlers to sort based on `CreatedAt` `Desc`

tested on the `core` repo, and generation works and you can see the `orderBy` added

```
8:06PM DBG Users/sarahfunkhouser/go/pkg/mod/entgo.io/ent@v0.14.4/dialect/dialect.go:79 | driver.Query: query=SELECT "tasks"."id", "tasks"."title", "tasks"."due", "tasks"."created_at" FROM "tasks" WHERE ("tasks"."status" IN ($1, $2, $3) AND "tasks"."deleted_at" IS NULL) AND "tasks"."owner_id" IN ($4) ORDER BY "tasks"."created_at" DESC, "tasks"."id" LIMIT 1000 args=[OPEN IN_PROGRESS IN_REVIEW 01JVWXKRP0CEWCVRS2QDZ0W3H7]
```