### PR TITLE
Bulk update templates

### DIFF
--- a/bulkgen/bulk.gotpl
+++ b/bulkgen/bulk.gotpl
@@ -36,6 +36,47 @@ func (r *mutationResolver) bulkCreate{{ $object.Name }} (ctx context.Context, in
 		{{ $object.PluralName }}: res,
 	}, nil
 }
+{{- else if eq $object.OperationType "update" }}
+// bulkUpdate{{ $object.Name }} updates multiple {{ $object.Name }} entities
+func (r *mutationResolver) bulkUpdate{{ $object.Name }} (ctx context.Context, input []*{{ $root.ModelPackage }}BulkUpdate{{ $object.Name }}Input) (*{{ $root.ModelPackage }}{{ $object.Name }}BulkUpdatePayload, error) {
+	if len(input) == 0 {
+		return nil, rout.NewMissingRequiredFieldError("input")
+	}
+
+	c := withTransactionalMutation(ctx)
+	results := make([]*generated.{{ $object.Name }}, 0, len(input))
+	updatedIDs := make([]string, 0, len(input))
+	
+	// update each {{ $object.Name | toLower }} individually to ensure proper validation
+	for _, updateInput := range input {
+		if updateInput.ID == "" {
+			log.Error().Msg("missing id in bulk update for {{ $object.Name | toLower }}")
+			continue
+		}
+
+		// get the existing entity first
+		existing, err := c.{{ $object.Name }}.Get(ctx, updateInput.ID)
+		if err != nil {
+			log.Error().Err(err).Str("{{ $object.Name | toLower }}_id", updateInput.ID).Msg("failed to get {{ $object.Name | toLower }} in bulk update operation")
+			continue
+		}
+
+		// setup update request
+		updatedEntity, err := existing.Update().SetInput(*updateInput.Input).Save(ctx)
+		if err != nil {
+			log.Error().Err(err).Str("{{ $object.Name | toLower }}_id", updateInput.ID).Msg("failed to update {{ $object.Name | toLower }} in bulk operation")
+			continue
+		}
+
+		results = append(results, updatedEntity)
+		updatedIDs = append(updatedIDs, updateInput.ID)
+	}
+
+	return &{{ $root.ModelPackage }}{{ $object.Name }}BulkUpdatePayload{
+		{{ $object.PluralName }}: results,
+		UpdatedIDs: updatedIDs,
+	}, nil
+}
 {{- else if eq $object.OperationType "delete" }}
 // bulkDelete{{ $object.Name }} deletes multiple {{ $object.Name }} entities by their IDs
 func (r *mutationResolver) bulkDelete{{ $object.Name }} (ctx context.Context, ids []string) (*{{ $root.ModelPackage }}{{ $object.Name }}BulkDeletePayload, error) {

--- a/bulkgen/bulkresolvers.go
+++ b/bulkgen/bulkresolvers.go
@@ -152,6 +152,12 @@ func (m *Plugin) generateSingleFile(data codegen.Data) error {
 			case strings.Contains(lowerName, "bulkcreate"):
 				objectName = strings.Replace(f.Name, "bulkCreate", "", 1)
 				operationType = "create"
+			case strings.Contains(lowerName, "updatebulk"):
+				objectName = strings.Replace(f.Name, "updateBulk", "", 1)
+				operationType = "update"
+			case strings.Contains(lowerName, "bulkupdate"):
+				objectName = strings.Replace(f.Name, "bulkUpdate", "", 1)
+				operationType = "update"
 			case strings.Contains(lowerName, "deletebulk"):
 				objectName = strings.Replace(f.Name, "deleteBulk", "", 1)
 				operationType = "delete"

--- a/resolvergen/templates/bulk.gotpl
+++ b/resolvergen/templates/bulk.gotpl
@@ -1,8 +1,10 @@
 {{ reserveImport "github.com/theopenlane/utils/rout" }}
+{{ reserveImport "github.com/rs/zerolog/log" }}
 
 {{ $entity := .Field.TypeReference.Definition.Name | getEntityName  -}}
 {{ $isOrgOwned := .Field | hasOwnerField  -}}
 {{ $isDelete := or (contains .Field.GoFieldName "Delete") (contains .Field.GoFieldName "delete") -}}
+{{ $isUpdate := or (contains .Field.GoFieldName "Update") (contains .Field.GoFieldName "update") -}}
 
 {{- if $isDelete }}
 if len(ids) == 0 {
@@ -10,6 +12,20 @@ if len(ids) == 0 {
 }
 
 return r.bulkDelete{{ $entity }}(ctx, ids)
+{{- else if $isUpdate }}
+if len(input) == 0 {
+    return nil, rout.NewMissingRequiredFieldError("input")
+}
+
+// set the organization in the auth context if its not done for us
+// this will choose the first input OwnerID when using a personal access token
+if err := setOrganizationInAuthContextBulkRequest(ctx, input); err != nil {
+    log.Error().Err(err).Msg("failed to set organization in auth context")
+
+    return nil, rout.NewMissingRequiredFieldError("owner_id")
+}
+
+return r.bulkUpdate{{ $entity }}(ctx, input)
 {{- else }}
 if len(input) == 0 {
     return nil, rout.NewMissingRequiredFieldError("input")


### PR DESCRIPTION
Add support for bulk updates in the templates

```

mutation BulkUpdateControl($input: [BulkUpdateControlInput!]!) {
  bulkUpdateControl(input: $input) {
    controls {
      assessmentMethods
    }
    updatedIDs
  }
}
```

```go
func (r *mutationResolver) BulkUpdateControl(ctx context.Context, input []*model.BulkUpdateControlInput) (*model.ControlBulkUpdatePayload, error) {
 if len(input) == 0 {
  return nil, rout.NewMissingRequiredFieldError("input")
 }

 // set the organization in the auth context if its not done for us
 // this will choose the first input OwnerID when using a personal access token
 if err := setOrganizationInAuthContextBulkRequest(ctx, input); err != nil {
  log.Error().Err(err).Msg("failed to set organization in auth context")

  return nil, rout.NewMissingRequiredFieldError("owner_id")
 }

 return r.bulkUpdateControl(ctx, input)
}
```
