### PR TITLE
Allow for file uploads to be used to import schemas

### DIFF
--- a/resolvergen/crud.go
+++ b/resolvergen/crud.go
@@ -163,12 +163,13 @@ const (
 	BulkOperation    = "Bulk"
 	CSVOperation     = "CSV"
 	BulkCSVOperation = "BulkCSV"
+	UploadOperation  = "Upload"
 	Connection       = "Connection"
 	Payload          = "Payload"
 )
 
 // crudTypes is a list of CRUD operations that are included in the resolver name
-var stripStrings = []string{CreateOperation, UpdateOperation, DeleteOperation, BulkOperation, CSVOperation, Connection, Payload}
+var stripStrings = []string{CreateOperation, UpdateOperation, DeleteOperation, BulkOperation, CSVOperation, UploadOperation, Connection, Payload}
 
 // getEntityName returns the entity name by stripping the CRUD operation from the resolver name
 func getEntityName(name string) string {

--- a/resolvergen/resolver.go
+++ b/resolvergen/resolver.go
@@ -138,6 +138,8 @@ func (r *ResolverPlugin) mutationImplementer(f *codegen.Field) string {
 		return r.renderBulkUpload(f)
 	case BulkOperation:
 		return r.renderBulk(f)
+	case UploadOperation:
+		return r.renderBulkUpload(f)
 	case CreateOperation:
 		return r.renderCreate(f)
 	case UpdateOperation:
@@ -169,6 +171,8 @@ func crudType(f *codegen.Field) string {
 		return BulkCSVOperation
 	case strings.Contains(f.GoFieldName, BulkOperation):
 		return BulkOperation
+	case strings.Contains(f.GoFieldName, UploadOperation):
+		return UploadOperation
 	case strings.Contains(f.GoFieldName, CreateOperation):
 		return CreateOperation
 	case strings.Contains(f.GoFieldName, UpdateOperation),

--- a/resolvergen/templates/upload.gotpl
+++ b/resolvergen/templates/upload.gotpl
@@ -8,10 +8,10 @@
 {{ if $hasOwnerIDParam }}
 var {{ $entity | toLowerCamel }}Input generated.Create{{ $entity }}Input
 
-{{ $entity | toLowerCamel }}Input.OwnerID = &ownerID
+{{ $entity | toLowerCamel }}Input.OwnerID = ownerID
 
 // set the organization in the auth context if its not done for us
-if err := setOrganizationInAuthContext(ctx, &ownerID); err != nil {
+if err := setOrganizationInAuthContext(ctx, ownerID); err != nil {
     log.Error().Err(err).Msg("failed to set organization in auth context")
     return nil, rout.NewMissingRequiredFieldError("owner_id")
 }

--- a/resolvergen/templates/upload.gotpl
+++ b/resolvergen/templates/upload.gotpl
@@ -2,7 +2,30 @@
 
 {{ $entity := .Field.TypeReference.Definition.Name | getEntityName  -}}
 {{ $isOrgOwned := .Field | hasOwnerField  -}}
+{{ $hasOwnerIDParam := hasArgument "ownerID" .Field.FieldDefinition.Arguments -}}
+{{ $modelPackage := .ModelPackage | modelPackage -}}
 
+{{ if $hasOwnerIDParam }}
+var {{ $entity | toLowerCamel }}Input generated.Create{{ $entity }}Input
+
+{{ $entity | toLowerCamel }}Input.OwnerID = &ownerID
+
+// set the organization in the auth context if its not done for us
+if err := setOrganizationInAuthContext(ctx, &ownerID); err != nil {
+    log.Error().Err(err).Msg("failed to set organization in auth context")
+    return nil, rout.NewMissingRequiredFieldError("owner_id")
+}
+
+res, err := withTransactionalMutation(ctx).{{ $entity }}.Create().SetInput({{ $entity | toLowerCamel }}Input).Save(ctx)
+if err != nil {
+	return nil, parseRequestError(err, action{action: ActionCreate, object: "{{ $entity | toLower }}"})
+}
+
+return &{{ $modelPackage }}{{ $entity }}CreatePayload{
+	{{ $entity }}: res,
+}, nil
+
+{{ else }}
 data, err := unmarshalBulkData[generated.Create{{ $entity }}Input](input)
 if err != nil {
 	log.Error().Err(err).Msg("failed to unmarshal bulk data")
@@ -18,10 +41,11 @@ if len(data) == 0 {
 // set the organization in the auth context if its not done for us
 // this will choose the first input OwnerID when using a personal access token
 if err := setOrganizationInAuthContextBulkRequest(ctx, data); err != nil {
-    log.Error().Err(err).Msg("failed to set organization in auth context")
+	log.Error().Err(err).Msg("failed to set organization in auth context")
 
-    return nil, rout.NewMissingRequiredFieldError("owner_id")
+	return nil, rout.NewMissingRequiredFieldError("owner_id")
 }
 {{- end }}
 
 return r.bulkCreate{{ $entity }}(ctx, data)
+{{ end }}

--- a/resolvergen/templates/upload.gotpl
+++ b/resolvergen/templates/upload.gotpl
@@ -8,7 +8,9 @@
 {{ if $hasOwnerIDParam }}
 var {{ $entity | toLowerCamel }}Input generated.Create{{ $entity }}Input
 
-{{ $entity | toLowerCamel }}Input.OwnerID = ownerID
+if ownerID != nil && *ownerID != "" {
+	{{ $entity | toLowerCamel }}Input.OwnerID = ownerID
+}
 
 // set the organization in the auth context if its not done for us
 if err := setOrganizationInAuthContext(ctx, ownerID); err != nil {


### PR DESCRIPTION
Added support for using uploaded files to use as description and name of schemas. This will be useful for imports

```
mutation CreateUploadProcedure($input: Upload!, $ownerID: ID) {
  createUploadProcedure(input: $input, ownerID: $ownerID) {
    procedure {
     id
    }
  }
}
```

```go
func (r *mutationResolver) CreateUploadProcedure(ctx context.Context, input graphql.Upload, ownerID *string) (*model.ProcedureCreatePayload, error) {
 var procedureInput generated.CreateProcedureInput

 procedureInput.OwnerID = ownerID

 // set the organization in the auth context if its not done for us
 if err := setOrganizationInAuthContext(ctx, &ownerID); err != nil {
  log.Error().Err(err).Msg("failed to set organization in auth context")
  return nil, rout.NewMissingRequiredFieldError("owner_id")
 }

 res, err := withTransactionalMutation(ctx).Procedure.Create().SetInput(procedureInput).Save(ctx)
 if err != nil {
  return nil, parseRequestError(err, action{action: ActionCreate, object: "procedure"})
 }

 return &model.ProcedureCreatePayload{
  Procedure: res,
 }, nil
}
```
